### PR TITLE
Add Caliban to supported servers in Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ If you’re interested in working on support for other GraphQL servers, or integ
 
 - [Node.js](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-tracing)
 - [Ruby](https://github.com/uniiverse/apollo-tracing-ruby)
-- [Scala](https://github.com/sangria-graphql/sangria-slowlog#apollo-tracing-extension)
+- Scala
+  - [Sangria](https://github.com/sangria-graphql/sangria-slowlog#apollo-tracing-extension)
+  - [Caliban](https://ghostdogpr.github.io/caliban/docs/middleware.html#wrapper-types)
 - [Java](https://github.com/graphql-java/graphql-java/pull/577)
 - [Elixir](https://github.com/sikanhe/apollo-tracing-elixir)
 - .NET


### PR DESCRIPTION
Caliban supports Apollo Tracing.