### PR TITLE
Add ariadne to list of supported GraphQL servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ If you’re interested in working on support for other GraphQL servers, or integ
 ## Supported GraphQL Servers
 
 - [Node.js](https://github.com/apollographql/apollo-server/tree/HEAD/packages/apollo-tracing)
+- Python
+  - [ariadne](https://ariadnegraphql.org/docs/apollo-tracing)
 - [Ruby](https://github.com/uniiverse/apollo-tracing-ruby)
 - Scala
   - [Sangria](https://github.com/sangria-graphql/sangria-slowlog#apollo-tracing-extension)


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->