### PR TITLE
Add link to Strawberry tracing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you’re interested in working on support for other GraphQL servers, or integ
 - [Node.js](https://github.com/apollographql/apollo-server/tree/HEAD/packages/apollo-tracing)
 - Python
   - [ariadne](https://ariadnegraphql.org/docs/apollo-tracing)
+  - [Strawberry](https://strawberry.rocks/docs/operations/tracing#apollo)
 - [Ruby](https://github.com/uniiverse/apollo-tracing-ruby)
 - Scala
   - [Sangria](https://github.com/sangria-graphql/sangria-slowlog#apollo-tracing-extension)


### PR DESCRIPTION
Strawberry has an extension to enable Apollo tracing. This PR adds a link to it. 